### PR TITLE
Dialer settings: fix "Additional settings" up arrow inconsistency

### DIFF
--- a/src/com/android/phone/GsmUmtsAdditionalCallOptions.java
+++ b/src/com/android/phone/GsmUmtsAdditionalCallOptions.java
@@ -102,7 +102,7 @@ public class GsmUmtsAdditionalCallOptions extends
     public boolean onOptionsItemSelected(MenuItem item) {
         final int itemId = item.getItemId();
         if (itemId == android.R.id.home) {  // See ActionBar#setDisplayHomeAsUpEnabled()
-            CallFeaturesSetting.goUpToTopLevelSetting(this);
+            onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
Dialer > settings menu > settings > call settings > SIM card settings >
Additional settings and then press the back arrow, you should go back to "SIM card settings"
but, instead, you'll go to "call settings".

Back button bring us to the correct screen, use the same logic for up
arrow.

Change-Id: I3b786458ede78bf906e12017c2e6943c47999e06
Signed-off-by: Roman Birg <roman@cyngn.com>