### PR TITLE
phone: Fix crash in MSISDNEditPreference when changing phone num.

### DIFF
--- a/src/com/android/phone/GsmUmtsAdditionalCallOptions.java
+++ b/src/com/android/phone/GsmUmtsAdditionalCallOptions.java
@@ -42,6 +42,7 @@ public class GsmUmtsAdditionalCallOptions extends
         PreferenceScreen prefSet = getPreferenceScreen();
         mCLIRButton = (CLIRListPreference) prefSet.findPreference(BUTTON_CLIR_KEY);
         mCWButton = (CallWaitingCheckBoxPreference) prefSet.findPreference(BUTTON_CW_KEY);
+        mMSISDNButton = (MSISDNEditPreference) prefSet.findPreference(BUTTON_PN_KEY);
 
         mPreferences.add(mCLIRButton);
         mPreferences.add(mCWButton);
@@ -50,6 +51,7 @@ public class GsmUmtsAdditionalCallOptions extends
         if (icicle == null) {
             if (DBG) Log.d(LOG_TAG, "start to init ");
             mCLIRButton.init(this, false, mPhoneId);
+            mMSISDNButton.init(this, false, mPhoneId);
         } else {
             if (DBG) Log.d(LOG_TAG, "restore stored states");
             mInitIndex = mPreferences.size();

--- a/src/com/android/phone/MSISDNEditPreference.java
+++ b/src/com/android/phone/MSISDNEditPreference.java
@@ -57,7 +57,7 @@ public class MSISDNEditPreference extends EditTextPreference {
     protected void onDialogClosed(boolean positiveResult) {
         super.onDialogClosed(positiveResult);
 
-        if (positiveResult) {
+        if (positiveResult && mPhone != null) {
             String alphaTag = mPhone.getLine1AlphaTag();
             if (TextUtils.isEmpty(alphaTag)) {
                 // No tag, set it.


### PR DESCRIPTION
When GsmUmtsAdditionalCallOptions's onCreate is called w/o a
Bundle handle, mMSISDNButton.init won't get called, hence
MSISDNEditPreference's mPhone is not initialized, which causes a
crash when onDialogClosed accesses mPhone.

* mMSISDNButton was not initialized, retrieve handle from prefSet
* Call mMSISDNButton.init to make sure mPhone is initialized

Change-Id: Ia0b629dab69edbc76d542dc603251f4d98715227